### PR TITLE
Update tinker.cfg

### DIFF
--- a/pkg/skills/metalworking/tinker.cfg
+++ b/pkg/skills/metalworking/tinker.cfg
@@ -217,7 +217,7 @@ tinkeritem 0x1030
 {
 	name		jointing plane
 	skill		20
-	difficulty	20
+//	difficulty	10
 	points		20
 	exceptional	1
 
@@ -228,7 +228,7 @@ tinkeritem 0x102c
 {
 	name		moulding plane
 	skill		20
-	difficulty	20
+//	difficulty	20
 	points		20
 	exceptional	1
 
@@ -239,7 +239,7 @@ tinkeritem 0x1032
 {
 	name		smoothing plane
 	skill		20
-	difficulty	20
+//	difficulty	20
 	points		20
 	exceptional	1
 
@@ -300,8 +300,8 @@ tinkeritem 0x10e1
 {
 	name		barrel hoops
 	skill		50
-	difficulty	50
-	points		20
+//	difficulty	20
+	points		10
 
 	materials	metal		5
 }
@@ -310,8 +310,8 @@ tinkeritem 0x1004
 {
 	name		barrel tap
 	skill		45
-	difficulty	45
-	points		20
+//	difficulty	25
+	points		5
 
 	materials	metal		2
 }
@@ -341,8 +341,8 @@ tinkeritem 0x1053
 {
 	name		gears
 	skill		50
-	difficulty	50
-	points		20
+	difficulty	35
+	points		10
 
 	materials	metal		2
 }
@@ -350,9 +350,9 @@ tinkeritem 0x1053
 tinkeritem 0x1055
 {
 	name		hinge
-	skill		50
-	difficulty	50
-	points		20
+	skill		40
+//	difficulty	20
+	points		10
 
 	materials	metal		2
 }
@@ -360,9 +360,9 @@ tinkeritem 0x1055
 tinkeritem 0x105d
 {
 	name		springs
-	skill		50
-	difficulty	50
-	points		20
+	skill		25
+//	difficulty	15
+	points		5
 
 	materials	metal		2
 }


### PR DESCRIPTION
- Correção da dificuldade de craft de itens de madeira; Da forma como estava o item necessitava de muita skill para aparecer no menu ou ser craftado, mais do que de fato era pedido no balanceamento existente.